### PR TITLE
Use freedomXhr.corexhr for Firefox, rename inviteUserData to inviteResponse

### DIFF
--- a/externs/freedom_extern.js
+++ b/externs/freedom_extern.js
@@ -15,10 +15,10 @@ SocialProviderInterface.prototype.inviteUser = function(userId, continuation) {}
 
 /**
  * @param {string} networkData
- * @param {string} inviteUserData
+ * @param {string} inviteResponse
  * @param {function(undefined=, Object=)} continuation
  */
-SocialProviderInterface.prototype.acceptUserInvitation = function(networkData, inviteUserData, continuation) {};
+SocialProviderInterface.prototype.acceptUserInvitation = function(networkData, inviteResponse, continuation) {};
 
 SocialProviderInterface.prototype.clearCachedCredentials = function() {};
 
@@ -32,7 +32,7 @@ SocialProviderInterface.prototype.getClients = function(continuation) {};
  */
 SocialProviderInterface.prototype.getUsers = function(continuation) {};
 
-/** 
+/**
  * @param {string} destination_id The userId or clientId to send to
  * @param {string} message The message to send.
  * @param {function(undefined=, Object=)} continuation Function to call once the message is sent

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-quiver",
   "description": "Multi-server Social Provider",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "homepage": "",
   "bugs": {
     "url": "http://github.com/uProxy/uproxy/issues"

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -1,7 +1,7 @@
 /*globals freedom:true, XMLHttpRequest:true, DEBUG */
 /*jslint indent:2, white:true, node:true, sloppy:true, browser:true */
 
-/** @type {{coretcpsocket}} */ var freedomXhr = require('freedom-xhr');
+/** @type {{coretcpsocket, corexhr}} */ var freedomXhr = require('freedom-xhr');
 
 // Use coretcpsocket does not yet work in Firefox, however in Firefox
 // corexhr supports domain fronting.

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -135,12 +135,13 @@
         "status": "string",
         "lastUpdated": "number",
         "lastSeen": "number",
-        "inviteUserData": "string"
+        "inviteResponse": "string"
       }}
     }
   },
   "permissions": [
     "core.storage",
-    "core.tcpsocket"
+    "core.tcpsocket",
+    "core.xhr"
   ]
 }


### PR DESCRIPTION
- Use freedomXhr.corexhr for Firefox - this works with domain fronting (unlike in Chrome where we aren't allowed to set the "Host" header on the XMLHttpRequest object)
- Rename inviteUserData to inviteResponse

Tested with uProxy in Chrome and Firefox.  A related uProxy/uProxy pull request is coming soon
