### PR TITLE
Report successful login as soon as we have connected as owner once

### DIFF
--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -324,6 +324,13 @@ QuiverSocialProvider.prototype.login = function(loginOpts, continuation) {
       }
     }.bind(this)).then(function() {
       if (this.finishLogin_) {
+        console.warn('All server connection attempts failed!');
+        // Arguably, we should report failure, not success at this point.
+        // However, the only way for the user to get back to a working state is
+        // to accept an invitation that includes a new (working) server, and
+        // they can't do that unless login has succeeded.
+        // TODO: Report failure once Quiver and application code allow us to
+        // process invitations without being logged in.
         this.finishLogin_();
       }
     }.bind(this));

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -144,7 +144,6 @@ QuiverSocialProvider.configuration_ = undefined;
  */
 QuiverSocialProvider.connection_ = undefined;
 
-
 /**
  * @param {!Array<T>} list To shuffle.  Not modified.
  * @param {number=} opt_sampleSize
@@ -233,6 +232,12 @@ QuiverSocialProvider.prototype.clearCachedCredentials = function() {
   // TODO(bemasc): What does this even mean?
 };
 
+
+/**
+ * @private {?Function}
+ */
+QuiverSocialProvider.prototype.finishLogin_ = null;
+
 /**
  * Connect to the Web Socket rendezvous server
  * e.g. social.login(Object options)
@@ -259,7 +264,8 @@ QuiverSocialProvider.prototype.login = function(loginOpts, continuation) {
 
     this.setNick_(loginOpts.userName);
 
-    var finishLogin = function() {
+    this.finishLogin_ = function() {
+      this.finishLogin_ = null;
       // Fulfill the method callback
       var clientState = this.makeClientState_(this.configuration_.self.id, this.clientSuffix_);
       continuation(clientState);
@@ -316,7 +322,11 @@ QuiverSocialProvider.prototype.login = function(loginOpts, continuation) {
         return this.connectLoop_(unusedDefaultServers,
             this.connectAsOwner_.bind(this), deficit);
       }
-    }.bind(this)).then(finishLogin);
+    }.bind(this)).then(function() {
+      if (this.finishLogin_) {
+        this.finishLogin_();
+      }
+    }.bind(this));
   }.bind(this));
 };
 
@@ -480,6 +490,10 @@ QuiverSocialProvider.prototype.connectAsOwner_ = function(server, continuation) 
 
     // Add the server to our public list of contact points.
     this.addServer_(server);
+
+    if (this.finishLogin_) {
+      this.finishLogin_();
+    }
   }.bind(this)).catch(function(err) {
     continuation(undefined, err);
   });


### PR DESCRIPTION
This accelerates login, leaving buddy list and presence information
to trickle in after login completes.
