### PR TITLE
Add encryption to Quiver

### DIFF
--- a/externs/freedom_extern.js
+++ b/externs/freedom_extern.js
@@ -2,19 +2,19 @@
 function SocialProviderInterface() {};
 
 /**
- * @param {{userName: string, agent: string}} loginOptions
+ * @param {{userName: string, pgpKeyName: ?string, agent: string}} loginOptions
  * @param {function((!Object|undefined), Object=)} continuation First argument is an onStatus event, send is an optional error message.
  */
 SocialProviderInterface.prototype.login = function(loginOptions, continuation) {};
 
 /**
  * @param {string} userId
- * @param {function(({networkData:string}|undefined), Object=)} continuation
+ * @param {function((Object|undefined), Object=)} continuation
  */
 SocialProviderInterface.prototype.inviteUser = function(userId, continuation) {};
 
 /**
- * @param {string} networkData
+ * @param {*} networkData
  * @param {string} inviteResponse
  * @param {function(undefined=, Object=)} continuation
  */
@@ -100,14 +100,20 @@ FreedomPgp.prototype.exportKey = function() {}
 
 /**
  * @param {!ArrayBuffer} plainText
- * @param {string} pubKey
+ * @param {?string=} pubKey
  * @return {!Promise<!ArrayBuffer>}
  */
 FreedomPgp.prototype.signEncrypt = function(plainText, pubKey) {}
 
 /**
  * @param {!ArrayBuffer} cipherText
- * @param {string} pubKey
+ * @param {?string=} pubKey
  * @return {!Promise<{data: !ArrayBuffer, signedBy: Array<string>}>}
  */
 FreedomPgp.prototype.verifyDecrypt = function(cipherText, pubKey) {}
+
+/**
+ * @param {string} pubKey
+ * @return {!Promise<{fingerprint: string, words: Array<string>}>}
+ */
+FreedomPgp.prototype.getFingerprint = function(pubKey) {}

--- a/externs/freedom_extern.js
+++ b/externs/freedom_extern.js
@@ -73,3 +73,33 @@ FreedomWebSocket.prototype.on = function(msg, handler) {};
 FreedomWebSocket.prototype.send = function(msg) {};
 
 FreedomWebSocket.prototype.close = function() {};
+
+/** @interface */
+function FreedomPgp() {};
+
+/**
+ * @param {string} passphrase
+ * @param {string} uid
+ * @return {!Promise<void>}
+ */
+FreedomPgp.prototype.setup = function(passphrase, uid) {}
+
+/**
+ * @return {!Promise<{key: string, fingerprint: string, words: Array<string>}>}
+ */
+FreedomPgp.prototype.exportKey = function() {}
+
+/**
+ * @param {!ArrayBuffer} plainText
+ * @param {string} pubKey
+ * @return {!Promise<!ArrayBuffer>}
+ */
+FreedomPgp.prototype.signEncrypt = function(plainText, pubKey) {}
+
+/**
+ * @param {!ArrayBuffer} cipherText
+ * @param {string} pubKey
+ * @return {!Promise<{data: !ArrayBuffer, signedBy: Array<string>}>}
+ */
+FreedomPgp.prototype.verifyDecrypt = function(cipherText, pubKey) {}
+

--- a/externs/freedom_extern.js
+++ b/externs/freedom_extern.js
@@ -75,6 +75,15 @@ FreedomWebSocket.prototype.send = function(msg) {};
 FreedomWebSocket.prototype.close = function() {};
 
 /** @interface */
+function FreedomCrypto() {};
+
+/**
+ * @param {number} numBytes
+ * @return {!Promise<!ArrayBuffer>}
+ */
+FreedomCrypto.prototype.getRandomBytes = function(numBytes) {}
+
+/** @interface */
 function FreedomPgp() {};
 
 /**
@@ -102,4 +111,3 @@ FreedomPgp.prototype.signEncrypt = function(plainText, pubKey) {}
  * @return {!Promise<{data: !ArrayBuffer, signedBy: Array<string>}>}
  */
 FreedomPgp.prototype.verifyDecrypt = function(cipherText, pubKey) {}
-

--- a/externs/freedom_extern.js
+++ b/externs/freedom_extern.js
@@ -15,10 +15,10 @@ SocialProviderInterface.prototype.inviteUser = function(userId, continuation) {}
 
 /**
  * @param {*} networkData
- * @param {string} inviteResponse
  * @param {function(undefined=, Object=)} continuation
  */
-SocialProviderInterface.prototype.acceptUserInvitation = function(networkData, inviteResponse, continuation) {};
+SocialProviderInterface.prototype.acceptUserInvitation = function(networkData,
+    continuation) {};
 
 SocialProviderInterface.prototype.clearCachedCredentials = function() {};
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "Gruntfile.js",
   "dependencies": {
     "debug": "0.7.4",
-    "freedom-xhr": "^0.0.7",
+    "freedom-xhr": "^0.0.8",
     "frontdomain": "^0.0.0",
     "parseuri": "^0.0.4",
     "socket.io-client": "^1.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-quiver",
   "description": "Multi-server Social Provider",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "homepage": "",
   "bugs": {
     "url": "http://github.com/uProxy/uproxy/issues"
@@ -16,7 +16,7 @@
   "main": "Gruntfile.js",
   "dependencies": {
     "debug": "0.7.4",
-    "freedom-xhr": "^0.0.6",
+    "freedom-xhr": "^0.0.7",
     "frontdomain": "^0.0.0",
     "parseuri": "^0.0.4",
     "socket.io-client": "^1.2"

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -576,6 +576,7 @@ QuiverSocialProvider.prototype.connect_ = function(server) {
     // user IDs I do not yet know.  This is safe because the ping contains no
     // sensitive information.
     // TODO: Prevent replays, e.g. by adding a timestamp.
+    // TODO: Is it safe to include the client suffix here?  This is plaintext.
     return this.signEncryptMessage_({
       cmd: 'ping',
       fromClient: this.clientSuffix_

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -337,8 +337,8 @@ QuiverSocialProvider.prototype.login = function(loginOpts, continuation) {
     }.bind(this);
 
     // The server connection heuristic is currently a three-step process.
-    // Step 1: Connect to my own long-term servers as an owner (i.e. listening
-    // for messages from friends).
+    // Step 1: Once I know my own public key, connect to my own long-term
+    // servers as an owner (i.e. listening for messages from friends).
     this.getPubKey_.then(function() {
       return this.connectLoop_(this.configuration_.self.servers,
           this.connectAsOwner_.bind(this));
@@ -1113,10 +1113,10 @@ QuiverSocialProvider.prototype.onEncryptedMessage_ = function(server, msg) {
 
 /**
  * Interpret decrypted messages from another user.
- * There are 3 types of messages
- * - Application messages (msg)
- * - Introduction/state update message (intro)
- * - Disconnection messages (disconnected)
+ * There are 3 types of commands in these messages
+ * - Application message comands (msg)
+ * - Introduction/state update commands (intro)
+ * - Disconnection commands (disconnected)
  *
  * @method onMessage
  * @private

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -6,6 +6,12 @@
       "socketio.quiver.js"
    	]
   },
+  "dependencies": {
+    "pgp-e2e": {
+      "url": "../freedom-pgp-e2e/pgpapi.json",
+      "api": "crypto"
+    }
+  },
   "default": "social2",
   "provides": [
     "social2"

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -146,6 +146,7 @@
     }
   },
   "permissions": [
+    "core.crypto",
     "core.storage",
     "core.tcpsocket",
     "core.xhr"

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -67,7 +67,7 @@
 
       "acceptUserInvitation": {
        "type": "method",
-        "value": ["string", "string"]
+        "value": ["object", "string"]
       },
 
       "sendEmail": {

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -44,7 +44,8 @@
           "url": "string",
           "interactive": "boolean",
           "rememberLogin": "boolean",
-          "userName": "string"
+          "userName": "string",
+          "pgpKeyName": "string"
         }],
         "ret": {
           "userId": "string",

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -66,8 +66,8 @@
       },
 
       "acceptUserInvitation": {
-       "type": "method",
-        "value": ["object", "string"]
+        "type": "method",
+        "value": ["object"]
       },
 
       "sendEmail": {


### PR DESCRIPTION
This ensures that server lists and nicknames don't leak to hostile servers.

Note that this depends on a pending improvement to freedom-xhr to avoid a truncation issue (which turns out to be a bug in Chrome): https://github.com/uProxy/freedom-xhr/pull/2
