### PR TITLE
Add new Quiver servers

### DIFF
--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -84,6 +84,26 @@ QuiverSocialProvider.DEFAULT_SERVERS_ = [{
   type: 'socketio',
   domain: 'd1j0v91oi5t6ys.cloudfront.net',
   front: 'a0.awsstatic.com'
+}, {
+  type: 'socketio',
+  domain: 'dzgea1sj9ik08.cloudfront.net',
+  front: 'a0.awsstatic.com'
+}, {
+  type: 'socketio',
+  domain: 'd2oi2yhmhpjpt7.cloudfront.net',
+  front: 'a0.awsstatic.com'
+}, {
+  type: 'socketio',
+  domain: 'd2cqtpyb8m6x8r.cloudfront.net',
+  front: 'a0.awsstatic.com'
+}, {
+  type: 'socketio',
+  domain: 'd3h805atiromvi.cloudfront.net',
+  front: 'a0.awsstatic.com'
+}, {
+  type: 'socketio',
+  domain: 'd2yp1zilrgqkqt.cloudfront.net',
+  front: 'a0.awsstatic.com'
 }];
 
 /**
@@ -352,7 +372,7 @@ QuiverSocialProvider.connectLoopResults_ = undefined;
  * @param {function(!QuiverSocialProvider.server_, Function)} connector
  * @param {number=} opt_limit Optional limit, defaults to MAX_CONNECTIONS
  * @return {!Promise<!QuiverSocialProvider.connectLoopResults_>} Always fulfills.
- *     
+ *
  * @private
  */
 QuiverSocialProvider.prototype.connectLoop_ = function(servers, connector,


### PR DESCRIPTION
Add new Quiver servers.  Each of these new servers is a $5 Ubuntu Droplet, running in the NY region on Digital Ocean, and CloudFronted through Amazon.  They all have logging setup as per instructions on https://github.com/uProxy/freedom-social-quiver-server/blob/96e6b7ad029928c38d191b4404d567176cd3c631/README.md
