### PR TITLE
Cleanup logout, OFFLINE and unlisten_ logic

### DIFF
--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -693,6 +693,7 @@ QuiverSocialProvider.prototype.cleanupServer_ = function(serverKey) {
     this.warn_('cleanupServer_ called for unknown server ' + JSON.stringify(server));
     return;
   }
+  this.log_('cleanupServer_ for ' + serverKey);
   // Remove server from friend in this.clientConnections_
   connection.friends.forEach(function(userId) {
     var connections = this.clientConnections_[userId];
@@ -707,7 +708,7 @@ QuiverSocialProvider.prototype.cleanupServer_ = function(serverKey) {
     }
     connections.splice(index);
   }, this);
-  this.log_('cleanupServer_ deleting: ' + serverKey);
+  this.unlisten_(connection);
   delete this.connections_[serverKey];
 };
 
@@ -1213,7 +1214,6 @@ QuiverSocialProvider.prototype.logout = function(continuation) {
 
   for (var serverKey in this.connections_) {
     var conn = this.connections_[serverKey];
-    this.unlisten_(conn);
     if (conn.socket.connected) {
       conn.socket.close();
     }

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -589,7 +589,7 @@ QuiverSocialProvider.prototype.connect_ = function(server) {
     this.warn_('socketio: error for ' + serverUrl + ', ' + err);
   }.bind(this));
 
-  var onDisconnect = function() {
+  var onClose = function() {
     this.cleanupServer_(serverKey);
     if (!this.isOnline_() && !this.finishLogin_) {
       // Only logout if we are not in the middle of login (i.e.
@@ -612,7 +612,7 @@ QuiverSocialProvider.prototype.connect_ = function(server) {
     if (connectErrorCount > MAX_RETRIES) {
       this.warn_('disconnecting from ' + serverUrl + ' after MAX_RETRIES');
       socket.close();
-      onDisconnect();
+      onClose();
       reject(err);
     }
   }.bind(this));
@@ -620,7 +620,7 @@ QuiverSocialProvider.prototype.connect_ = function(server) {
   this.listen_(connection, "message", this.onEncryptedMessage_.bind(this, server));
   this.listen_(connection, "reconnect_failed", function(msg) {
     this.warn_('socketio: reconnect_failed for ' + serverUrl + ', ' + msg);
-    onDisconnect();
+    onClose();
     reject(new Error('Never connected to ' + serverUrl));
   }.bind(this));
 
@@ -675,7 +675,7 @@ QuiverSocialProvider.prototype.connect_ = function(server) {
 
   this.listen_(connection, "disconnect", function() {
     // This may be emitted when the user logs out of Quiver, in that case
-    // it is not an error.  We should not call onDisconnect here as we will
+    // it is not an error.  We should not call onClose here as we will
     // be attempting to reconnect.
     this.warn_('socketio: disconnect for ' + serverUrl);
   }.bind(this));

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -1204,14 +1204,6 @@ QuiverSocialProvider.prototype.emitEncrypted_ = function(connections, friend,
  * @override
  */
 QuiverSocialProvider.prototype.logout = function(continuation) {
-  this.dispatchEvent('onClientState', {
-    userId: this.configuration_.self.id,
-    clientId: this.configuration_.self.id + '#' + this.clientSuffix_,
-    status: 'OFFLINE',
-    lastUpdated: Date.now(),
-    lastSeen: Date.now()
-  });
-
   for (var serverKey in this.connections_) {
     var conn = this.connections_[serverKey];
     if (conn.socket.connected) {
@@ -1219,6 +1211,8 @@ QuiverSocialProvider.prototype.logout = function(continuation) {
     }
     this.cleanupServer_(serverKey);
   }
+  this.dispatchEvent('onClientState',
+      this.makeClientState_(this.configuration_.self.id, this.clientSuffix_));
 };
 
 /**


### PR DESCRIPTION
Fixes for #17 and #18:
- Don't emit an OFFLINE for the current client if we are still in login
- Final socket disconnect now invokes same cleanup as logout
- disconnect_ is now cleanupServer_ and is also invoked on logout
- cleanupServer_ also calls unlisten_
