### PR TITLE
Use providePromises for QuiverSocialProvider

### DIFF
--- a/externs/freedom_extern.js
+++ b/externs/freedom_extern.js
@@ -3,45 +3,46 @@ function SocialProviderInterface() {};
 
 /**
  * @param {{userName: string, pgpKeyName: ?string, agent: string}} loginOptions
- * @param {function((!Object|undefined), Object=)} continuation First argument is an onStatus event, send is an optional error message.
+ * @return {!Promise<!Object>} client state for logged in user
  */
-SocialProviderInterface.prototype.login = function(loginOptions, continuation) {};
+SocialProviderInterface.prototype.login = function(loginOptions) {};
 
 /**
  * @param {string} userId
- * @param {function((Object|undefined), Object=)} continuation
+ * @return {!Promise} Promise<void>
  */
-SocialProviderInterface.prototype.inviteUser = function(userId, continuation) {};
+SocialProviderInterface.prototype.inviteUser = function(userId) {};
 
 /**
  * @param {*} networkData
- * @param {function(undefined=, Object=)} continuation
+ * @return {!Promise} Promise<void>
  */
-SocialProviderInterface.prototype.acceptUserInvitation = function(networkData,
-    continuation) {};
+SocialProviderInterface.prototype.acceptUserInvitation = function(networkData) {};
 
+/**
+ * @return {!Promise} Promise<void>
+ */
 SocialProviderInterface.prototype.clearCachedCredentials = function() {};
 
 /**
- * @param {function((!Object|undefined), Object=)} continuation
+ * @return {!Promise} Mapping from clientId to client states
  */
-SocialProviderInterface.prototype.getClients = function(continuation) {};
+SocialProviderInterface.prototype.getClients = function() {};
 
 /**
- * @param {function((!Object|undefined), Object=)} continuation
+ * @return {!Promise} Mapping from userId to user profiles
  */
-SocialProviderInterface.prototype.getUsers = function(continuation) {};
+SocialProviderInterface.prototype.getUsers = function() {};
 
 /**
  * @param {string} destination_id The userId or clientId to send to
  * @param {string} message The message to send.
- * @param {function(undefined=, Object=)} continuation Function to call once the message is sent
- *     (not necessarily received).
+ * @return {!Promise} Promise<void>
  */
-SocialProviderInterface.prototype.sendMessage = function(destination_id, message, continuation) {};
+SocialProviderInterface.prototype.sendMessage = function(destination_id, message) {};
 
-/** @param {function(undefined=, Object=)} continuation */
-SocialProviderInterface.prototype.logout = function(continuation) {};
+/** @return {!Promise} Promise<void> */
+SocialProviderInterface.prototype.logout = function() {};
 
 /** @constructor @struct */
 function SocialInterface() {};
@@ -50,7 +51,7 @@ function SocialInterface() {};
 SocialInterface.prototype.ERRCODE;
 
 /** @param {!function(new:SocialProviderInterface, function())} x */
-SocialInterface.prototype.provideAsynchronous = function(x) {};
+SocialInterface.prototype.providePromises = function(x) {};
 
 
 /** @constructor @struct */


### PR DESCRIPTION
Use providePromises for the social2 API calls in QuiverSocialProvider.  I will create another pull request after this one to move the remaining functions (syncConfiguration_, connectLoop_, etc) to return Promises as well - that will help clean up some of the deeply indented code.

Tested in uProxy and verified no errors in the closure compiler.
